### PR TITLE
Fix tflint

### DIFF
--- a/tf-module-{{cookiecutter.module_name}}/.travis.yml
+++ b/tf-module-{{cookiecutter.module_name}}/.travis.yml
@@ -14,5 +14,5 @@ script:
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform validate -check-variables=false
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci tf_readme_validator.py
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci cred-alert scan -f .
-  - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci tflint --error-with-issues
+  - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci tflint --error-with-issues --ignore-module="terraform-aws-modules/vpc/aws"
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terrascan --location . --test all


### PR DESCRIPTION
 TFLint doesn't support v0.11 modules reported at [this](https://github.com/wata727/tflint/issues/206) and [this](https://github.com/wata727/tflint/issues/167)