### PR TITLE
fmt before init

### DIFF
--- a/tf-module-{{cookiecutter.module_name}}/.travis.yml
+++ b/tf-module-{{cookiecutter.module_name}}/.travis.yml
@@ -10,6 +10,7 @@ services:
 
 script:
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform fmt -check=true
+  - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform init
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform validate -check-variables=false
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci tf_readme_validator.py
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci cred-alert scan -f .

--- a/tf-module-{{cookiecutter.module_name}}/.travis.yml
+++ b/tf-module-{{cookiecutter.module_name}}/.travis.yml
@@ -9,8 +9,8 @@ services:
   - docker
 
 script:
-  - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform init
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform fmt -check=true
+  - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform init
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform validate -check-variables=false
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci tf_readme_validator.py
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci cred-alert scan -f .

--- a/tf-module-{{cookiecutter.module_name}}/.travis.yml
+++ b/tf-module-{{cookiecutter.module_name}}/.travis.yml
@@ -10,7 +10,6 @@ services:
 
 script:
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform fmt -check=true
-  - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform init
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform validate -check-variables=false
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci tf_readme_validator.py
   - docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci cred-alert scan -f .


### PR DESCRIPTION
`terraform fmt -check=true` found errors in `.terraform/` folder, in downloaded modules and there is no way to exclude .terraform folder from fmt, [issue](https://github.com/hashicorp/terraform/issues/6663).
Example:
``` 
docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform fmt -check=true
.terraform/modules/2d7f8de05bf87642b31ea419d307f76b/test/main.tf
The command "docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform fmt -check=true" exited with 3.
```
